### PR TITLE
docs: rebrand Azure Cosmos DB for MongoDB vCore -> Azure DocumentDB

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,4 +1,4 @@
-metadata description = 'Provisions resources for a web application that uses MongoDB driver for .NET to connect to Azure Cosmos DB for MongoDB vCore.'
+metadata description = 'Provisions resources for a web application that uses MongoDB driver for .NET to connect to Azure DocumentDB (with MongoDB compatibility).'
 
 targetScope = 'resourceGroup'
 
@@ -281,7 +281,7 @@ module containerAppsJsWebApp 'br/public:avm/res/app/container-app:0.16.0' = {
           }
           {
             name: 'SETTINGS__HEADERSUFFIX'
-            value: 'Azure Cosmos DB for MongoDB vCore - JavaScript'
+            value: 'Azure DocumentDB - JavaScript'
           }
         ]
       }
@@ -343,7 +343,7 @@ module containerAppsTsWebApp 'br/public:avm/res/app/container-app:0.16.0' = {
           }
           {
             name: 'SETTINGS__HEADERSUFFIX'
-            value: 'Azure Cosmos DB for MongoDB vCore - TypeScript'
+            value: 'Azure DocumentDB - TypeScript'
           }
         ]
       }

--- a/infra/mongo.bicep
+++ b/infra/mongo.bicep
@@ -1,6 +1,6 @@
-metadata description = 'Provisions resources for an Azure Cosmos DB for MongoDB vCore cluster.'
+metadata description = 'Provisions resources for an Azure DocumentDB (with MongoDB compatibility) cluster.'
 
-@description('The name of the Azure Cosmos DB for MongoDB vCore cluster.')
+@description('The name of the Azure DocumentDB cluster.')
 param name string
 
 @description('Primary location for the resources.')

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Azure Cosmos DB for MongoDB vCore Quickstart - MongoDB driver for Node.js
+# Azure DocumentDB (with MongoDB compatibility) Quickstart - MongoDB driver for Node.js
 
-This Quickstart is a Express API application that illustrates basic usage of the MongoDB driver for Node.js with [Azure Cosmos DB for MongoDB vCore](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore). [Azure Cosmos DB for MongoDB vCore](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/oss) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
+This Quickstart is a Express API application that illustrates basic usage of the MongoDB driver for Node.js with [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore). [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/oss) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
 
 ## Pre-requisites
 
@@ -20,7 +20,7 @@ architecture-beta
 
     service registry(server)[Container registry] in azure
     service identity(disk)[Managed identity] in azure
-    service data(database)[Azure Cosmos DB for MongoDB vCore] in azure
+    service data(database)[Azure DocumentDB] in azure
 
     group host(server)[Azure Container Apps] in azure
 
@@ -65,7 +65,7 @@ architecture-beta
 
 ## (Optional) Run the solution locally
 
-1. If you haven't deployed the solution already, provision the Azure infrastructure to deploy the Azure Cosmos DB for MongoDB vCore cluster with Microsoft Entra ID authentication enabled.
+1. If you haven't deployed the solution already, provision the Azure infrastructure to deploy the Azure DocumentDB cluster with Microsoft Entra ID authentication enabled.
 
     ```shell
     azd provision
@@ -81,7 +81,7 @@ architecture-beta
 
     | | Description |
     | --- | --- |
-    | **`SETTINGS__ENDPOINT`** | The endpoint to the Azure Cosmos DB for MongoDB vCore cluster |
+    | **`SETTINGS__ENDPOINT`** | The endpoint to the Azure DocumentDB cluster |
 
     ```output
     SETTINGS__ENDPOINT = <azure-cosmos-db-mongodb-vcore-cluster-name>.global.mongocluster.cosmos.azure.com

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Azure DocumentDB (with MongoDB compatibility) Quickstart - MongoDB driver for Node.js
 
-This Quickstart is a Express API application that illustrates basic usage of the MongoDB driver for Node.js with [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore). [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/oss) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
+This Quickstart is a Express API application that illustrates basic usage of the MongoDB driver for Node.js with [Azure DocumentDB](https://learn.microsoft.com/azure/documentdb/). [Azure DocumentDB](https://learn.microsoft.com/azure/documentdb/) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
 
 ## Pre-requisites
 


### PR DESCRIPTION
## Summary

Microsoft has renamed the managed MongoDB-compatible service from **Azure Cosmos DB for MongoDB vCore** to **Azure DocumentDB (with MongoDB compatibility)**. Wire protocol, connection strings, drivers, and APIs are unchanged.

This PR updates user-visible product references in this sample to the new name. No code identifiers, package names, namespaces, or class names were changed; only docs, descriptions, and log messages.

See: https://learn.microsoft.com/azure/documentdb/

## Convention used
- First reference per file: **Azure DocumentDB (with MongoDB compatibility)**
- Subsequent references: **Azure DocumentDB**

## Backward compatibility
No source or binary breakage. Existing class names, package paths, namespaces, and infra resource names are unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
